### PR TITLE
support template-haskell-2.10.0

### DIFF
--- a/src/Language/Haskell/TH/Instances.hs
+++ b/src/Language/Haskell/TH/Instances.hs
@@ -18,51 +18,65 @@
 module Language.Haskell.TH.Instances () where
 
 import GHC.Real (Ratio)
-import GHC.Word (Word8)
 import Language.Haskell.TH
 import Language.Haskell.TH.Instances.Internal
 import Language.Haskell.TH.Lift (deriveLiftMany)
-import Language.Haskell.TH.Ppr
 import Language.Haskell.TH.ReifyMany
 import Language.Haskell.TH.Syntax
 
+#if !MIN_VERSION_template_haskell(2,10,0)
+import GHC.Word (Word8)
+import Language.Haskell.TH.Ppr
+#endif
+
 -- Orphan Show instances
 
+#if !MIN_VERSION_template_haskell(2,10,0)
 deriving instance Show Loc
+#endif
 
 -- Orphan Eq instances
 
+#if !MIN_VERSION_template_haskell(2,10,0)
 deriving instance Eq Loc
 deriving instance Eq Info
+#endif
+
 #if MIN_VERSION_template_haskell(2,5,0) && !(MIN_VERSION_template_haskell(2,7,0))
 deriving instance Eq ClassInstance
 #endif
 
 -- Orphan Ord instances
 
+#if !MIN_VERSION_template_haskell(2,10,0)
 instance Ord FixityDirection where
   (<=) InfixL _      = True
   (<=) _      InfixR = True
   (<=) InfixN InfixN = True
   (<=) _      _      = False
+#endif
 
 $(reifyManyWithoutInstances ''Ord [''Info] (`notElem` [''Ratio]) >>=
   mapM deriveOrd)
 
 -- Orphan Ppr instances
 
+#if !MIN_VERSION_template_haskell(2,10,0)
 -- TODO: make this better
 instance Ppr Loc where
   ppr = showtextl . show
 
 instance Ppr Lit where
   ppr l = ppr (LitE l)
+#endif
 
 -- Orphan Lift instances (for when your TH generates TH!)
 
+#if !MIN_VERSION_template_haskell(2,10,0)
 -- This follows the pattern of the Lift instances for Int / Integer.
 instance Lift Word8 where
   lift w = [e| fromIntegral $(lift (fromIntegral w :: Int)) |]
+#endif
 
 $(reifyManyWithoutInstances ''Lift [''Info] (const True) >>=
   deriveLiftMany)


### PR DESCRIPTION
this removes the instances that are now implemented by the template haskell package when compiled with 2.10.0
