### PR TITLE
Generate a Lift instance for Language.Haskell.TH.Syntax.Loc

### DIFF
--- a/src/Language/Haskell/TH/Instances.hs
+++ b/src/Language/Haskell/TH/Instances.hs
@@ -60,5 +60,5 @@ deriving instance Eq ClassInstance
 $(reifyManyWithoutInstances ''Ord [''Info] (`notElem` [''Ratio]) >>=
   mapM deriveOrd)
 
-$(reifyManyWithoutInstances ''Lift [''Info] (const True) >>=
+$(reifyManyWithoutInstances ''Lift [''Info, ''Loc] (const True) >>=
   deriveLiftMany)


### PR DESCRIPTION
Useful for building error messages.