### PR TITLE
Merge instances from th-compat

### DIFF
--- a/src/Language/Haskell/TH/Instances.hs
+++ b/src/Language/Haskell/TH/Instances.hs
@@ -41,7 +41,6 @@ import Language.Haskell.TH.Syntax
 -- from this module.
 #if !MIN_VERSION_template_haskell(2,10,0)
 import Data.Int (Int8, Int16, Int32, Int64)
--- import Data.Ratio (Ratio)
 import Data.Word (Word8, Word16, Word32, Word64)
 import Numeric.Natural (Natural)
 
@@ -115,9 +114,6 @@ instance Lift Word64 where
 
 instance Lift Natural where
     lift x = return (LitE (IntegerL (fromIntegral x)))
-
--- instance Integral a => Lift (Ratio a) where
---     lift x = return (LitE (RationalL (toRational x)))
 
 instance Lift Float where
     lift x = return (LitE (RationalL (toRational x)))

--- a/th-orphans.cabal
+++ b/th-orphans.cabal
@@ -19,6 +19,7 @@ description:        Orphan instances for TH datatypes.  In particular, instances
 
 library
   build-depends:    base >= 4.2 && < 5,
+                    nats >= 0.1 && < 2,
                     template-haskell,
                     th-lift >= 0.5,
                     th-reify-many >= 0.1 && < 0.2

--- a/th-orphans.cabal
+++ b/th-orphans.cabal
@@ -23,6 +23,11 @@ library
                     template-haskell,
                     th-lift >= 0.5,
                     th-reify-many >= 0.1 && < 0.2
+
+  -- Prior to GHC 7.6, GHC generics lived in ghc-prim
+  if impl(ghc >= 7.2) && impl(ghc < 7.6)
+    build-depends:  ghc-prim
+
   hs-source-dirs:   src
   ghc-options:      -Wall
   exposed-modules:  Language.Haskell.TH.Instances


### PR DESCRIPTION
Recently, I decided to make a package called [`th-compat`](https://github.com/RyanGlScott/th-compat/blob/f796d25e10d18e3c9b51deebfbb493f530d84629/src/Language/Haskell/TH/Orphans.hs) which backports type class instances provided in later versions of `template-haskell`, later to discover you already have such a package! Oops.

To avoid duplicating effort, I want to merge in all of the instances that `th-compat` provides that `th-orphans` doesn't have at the moment. This would add:

* `Generic` instances for all `Syntax`-related data types
* `Ord` instances for `Loc`, `AnnLookup`, and `ModuleInfo`
* `Eq` instance for `ModuleInfo`
* `Show` instances for `ModName`, `OccName`, and `PkgName`
* `Applicative` instances for `Q` and `PprM`
* `Functor` instance for `PprM`
* `Lift` instances for the numeric types, including `Nat` (which is why I added `nats` as a dependency, in case users aren't using GHC 7.10)
* `Data` and `Typeable` instances for `Loc`

Note that I made a couple of changes to your existing instances to make them work identically to how they behave in `template-haskell-2.10.0.0`, namely:

* I changed the `Ord FixityDirection` instance to a derived instance. Right now, `InfixN <= InfixR` evaluates to `True` with `th-orphans`, but to `False` with `template-haskell-2.10.0.0`.
* I only define instances for `Loc` if using `template-haskell-2.3.0` or greater, since that's when it was first introduced (as far as I can tell).
* I changed the implementation of `Ppr Lit` and `Lift Word8` to have an identical implementation to what `template-haskell-2.10.0.0` uses. It shouldn't affect the behavior of the code, just its appearance.

Other than that, the only issue I had was that there is an `Integral a => Lift (Ratio a)` instance in `template-haskell-2.10.0.0` that I couldn't add because `th-lift` [defines an overlapping `Lift Rational` instance](https://github.com/mboes/th-lift/blob/3fa3a11e92c961760910d476e2856cfbbd2a31cb/src/Language/Haskell/TH/Lift.hs#L159-160). I'll file a bug separately to resolve that.