### PR TITLE
Remove Lift Natural instance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,10 @@ env:
  - CABALVER=1.22 GHCVER=7.10.1   # template-haskell-2.10.0.0
  - CABALVER=head GHCVER=head   # see section about GHC HEAD snapshots
 
+matrix:
+  allow_failures:
+   - env: CABALVER=head GHCVER=head
+
 # Note: the distinction between `before_install` and `install` is not important.
 before_install:
  - travis_retry sudo add-apt-repository -y ppa:hvr/ghc

--- a/src/Language/Haskell/TH/Instances.hs
+++ b/src/Language/Haskell/TH/Instances.hs
@@ -66,7 +66,6 @@ import qualified Control.Monad.Trans as MTL (lift)
 #if !MIN_VERSION_template_haskell(2,10,0)
 import Data.Int (Int8, Int16, Int32, Int64)
 import Data.Word (Word8, Word16, Word32, Word64)
-import Numeric.Natural (Natural)
 
 import Language.Haskell.TH.Ppr
 # if MIN_VERSION_template_haskell(2,3,0)
@@ -137,9 +136,6 @@ instance Lift Word32 where
     lift x = return (LitE (IntegerL (fromIntegral x)))
 
 instance Lift Word64 where
-    lift x = return (LitE (IntegerL (fromIntegral x)))
-
-instance Lift Natural where
     lift x = return (LitE (IntegerL (fromIntegral x)))
 
 instance Lift Float where

--- a/th-orphans.cabal
+++ b/th-orphans.cabal
@@ -19,7 +19,6 @@ description:        Orphan instances for TH datatypes.  In particular, instances
 
 library
   build-depends:    base >= 4.2 && < 5,
-                    nats >= 0.1 && < 2,
                     template-haskell,
                     -- https://github.com/mboes/th-lift/issues/14
                     th-lift >= 0.7.1,


### PR DESCRIPTION
I goofed on commit cb3b68264381fe120e40f14d5624f7ca39231e98, since I brought in an orphan `Lift` instance for `Natural`. It didn't occur to me until much later that this makes far more sense to live in `nats`, since (1) it avoids incurring an orphan instance and (2) avoids bringing in `th-lift`, `th-derive-many`, etc. for those who just want to use the `Lift Natural` instance.

I propose moving this `Lift Natural` instance to `nats`. This requires a bit of coordination between `th-orphans` and `nats` to work. First, the instance needs to be removed from `th-orphans`, which this pull request accomplishes. The instance can then be safely added to `nats`.