### PR TITLE
Backport Show instances, eliminate GHC 8 warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,8 @@ env:
  - CABALVER=1.16 GHCVER=7.4.2  HACK=false # template-haskell-2.7.0.0
  - CABALVER=1.18 GHCVER=7.6.3  HACK=false # template-haskell-2.8.0.0
  - CABALVER=1.18 GHCVER=7.8.3  HACK=false # template-haskell-2.9.0.0
- - CABALVER=1.22 GHCVER=7.10.1 HACK=false # template-haskell-2.10.0.0
+ - CABALVER=1.22 GHCVER=7.10.3 HACK=false # template-haskell-2.10.0.0
+ - CABALVER=1.24 GHCVER=8.0.1  HACK=false # template-haskell-2.11.0.0
  - CABALVER=head GHCVER=head   HACK=false # see section about GHC HEAD snapshots
 
 matrix:

--- a/src/Language/Haskell/TH/Instances.hs
+++ b/src/Language/Haskell/TH/Instances.hs
@@ -103,6 +103,11 @@ import qualified Generics.Deriving.TH as Generic (deriveAll)
 # endif
 #endif
 
+#if !MIN_VERSION_template_haskell(2,11,0)
+deriving instance Show NameFlavour
+deriving instance Show NameSpace
+#endif
+
 -- Ideally, it'd be possible to use reifyManyWithoutInstances for
 -- these Ord instances, but TH can't output deriving instances (and
 -- even if this is added for later versions, we need to support many
@@ -360,6 +365,12 @@ instance Quasi m => Quasi (ReaderT r m) where
   qGetQ               = MTL.lift qGetQ
   qPutQ               = MTL.lift . qPutQ
 # endif
+# if MIN_VERSION_template_haskell(2,11,0)
+  qReifyFixity        = MTL.lift . qReifyFixity
+  qReifyConStrictness = MTL.lift . qReifyConStrictness
+  qIsExtEnabled       = MTL.lift . qIsExtEnabled
+  qExtsEnabled        = MTL.lift qExtsEnabled
+# endif
 #elif MIN_VERSION_template_haskell(2,5,0)
   qClassInstances a b = MTL.lift $ qClassInstances a b
 #endif
@@ -383,6 +394,12 @@ instance (Quasi m, Monoid w) => Quasi (WriterT w m) where
   qAddModFinalizer    = MTL.lift . qAddModFinalizer
   qGetQ               = MTL.lift qGetQ
   qPutQ               = MTL.lift . qPutQ
+# endif
+# if MIN_VERSION_template_haskell(2,11,0)
+  qReifyFixity        = MTL.lift . qReifyFixity
+  qReifyConStrictness = MTL.lift . qReifyConStrictness
+  qIsExtEnabled       = MTL.lift . qIsExtEnabled
+  qExtsEnabled        = MTL.lift qExtsEnabled
 # endif
 #elif MIN_VERSION_template_haskell(2,5,0)
   qClassInstances a b = MTL.lift $ qClassInstances a b
@@ -408,6 +425,12 @@ instance Quasi m => Quasi (StateT s m) where
   qGetQ               = MTL.lift qGetQ
   qPutQ               = MTL.lift . qPutQ
 # endif
+# if MIN_VERSION_template_haskell(2,11,0)
+  qReifyFixity        = MTL.lift . qReifyFixity
+  qReifyConStrictness = MTL.lift . qReifyConStrictness
+  qIsExtEnabled       = MTL.lift . qIsExtEnabled
+  qExtsEnabled        = MTL.lift qExtsEnabled
+# endif
 #elif MIN_VERSION_template_haskell(2,5,0)
   qClassInstances a b = MTL.lift $ qClassInstances a b
 #endif
@@ -431,6 +454,12 @@ instance (Quasi m, Monoid w) => Quasi (RWST r w s m) where
   qAddModFinalizer    = MTL.lift . qAddModFinalizer
   qGetQ               = MTL.lift qGetQ
   qPutQ               = MTL.lift . qPutQ
+# endif
+# if MIN_VERSION_template_haskell(2,11,0)
+  qReifyFixity        = MTL.lift . qReifyFixity
+  qReifyConStrictness = MTL.lift . qReifyConStrictness
+  qIsExtEnabled       = MTL.lift . qIsExtEnabled
+  qExtsEnabled        = MTL.lift qExtsEnabled
 # endif
 #elif MIN_VERSION_template_haskell(2,5,0)
   qClassInstances a b = MTL.lift $ qClassInstances a b

--- a/th-orphans.cabal
+++ b/th-orphans.cabal
@@ -10,7 +10,7 @@ copyright:          (c) Matt Morrow
 maintainer:         Michael Sloan <mgsloan at gmail>
 bug-reports:        https://github.com/mgsloan/th-orphans/issues
 stability:          experimental
-tested-with:        GHC == 7.4.2, GHC == 7.6.3, GHC == 7.8.3, GHC == 7.10.1
+tested-with:        GHC == 7.4.2, GHC == 7.6.3, GHC == 7.8.3, GHC == 7.10.3, GHC == 8.0.1
 synopsis:           Orphan instances for TH datatypes
 description:        Orphan instances for TH datatypes.  In particular, instances
                     for Ord and Lift, as well as a few missing Show / Eq.  These


### PR DESCRIPTION
GHC 8 introduces `Show` instances for `NameFlavour` and `NameSpace`. It also introduces some more methods for the `Quasi` class, so make sure those are defined for the monad transformer `Lift` instances.