### PR TITLE
Backport the MonadFail Q instance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### Not yet released
-* Allow building with `template-haskell-2.15` by manually implementing
+* Backport the `MonadFail Q` instance.
+* Allow building with `template-haskell-2.16` by manually implementing
   `Lift` for `Bytes`. See [#27]
 
 [#27]: https://github.com/mgsloan/th-orphans/issues/27

--- a/th-orphans.cabal
+++ b/th-orphans.cabal
@@ -36,6 +36,9 @@ library
                       th-lift-instances,
                       mtl
 
+  if !impl(ghc >= 8.0)
+    build-depends:    fail == 4.9.*
+
   -- Use TH to derive Generics instances instead of DeriveGeneric, for < 7.10
   if impl(ghc < 7.10)
     build-depends:    generic-deriving >= 1.9


### PR DESCRIPTION
While updating some code to adapt to upcoming `MonadFail` changes in `base-4.13`, I was thwarted by the fact that `Q` does not have a `MonadFail` instance prior to `template-haskell-2.11` (GHC 8.0). This seems like something that deserves to live in `th-orphans`.