### PR TITLE
Implement qReifyType in Quasi instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### next [????.??.??]
+* Implement `qReifyType` (introduced in `template-haskell-2.16.0.0`) for the
+  `Quasi` instances defined in `th-orphans`.
+
 ### 0.13.8 [2019.09.04]
 * Backport the `Bounded` instance for `Extension`
   (from `Language.Haskell.TH.LanguageExtensions`), which was introduced in

--- a/src/Language/Haskell/TH/Instances/Internal.hs
+++ b/src/Language/Haskell/TH/Instances/Internal.hs
@@ -84,6 +84,9 @@ deriveQuasiTrans qInstHead qRecoverExpr = do
 #if MIN_VERSION_template_haskell(2,13,0)
             , ('qAddCorePlugin,      [| MTL.lift . qAddCorePlugin |])
 #endif
+#if MIN_VERSION_template_haskell(2,16,0)
+            , ('qReifyType,          [| MTL.lift . qReifyType |])
+#endif
             ]
 
           mkDec :: Name -> Q Exp -> Q Dec


### PR DESCRIPTION
`Quasi` will introduce a `qReifyType` method in the upcoming `template-haskell-2.16.0.0` release.