### PR TITLE
Support template-haskell 2.17.

### DIFF
--- a/src/Language/Haskell/TH/Instances.hs
+++ b/src/Language/Haskell/TH/Instances.hs
@@ -433,7 +433,11 @@ instance Lift Bytes where
     |]
     where
       size = bytesSize bytes
+#if MIN_VERSION_template_haskell(2,17,0)
+  liftTyped = Code . unsafeTExpCoerce . lift
+#else
   liftTyped = unsafeTExpCoerce . lift
+#endif
 #endif
 
 #if !MIN_VERSION_template_haskell(2,17,0)

--- a/th-orphans.cabal
+++ b/th-orphans.cabal
@@ -31,7 +31,7 @@ extra-source-files: CHANGELOG.md, README.md
 
 library
   build-depends:      base >= 4.3 && < 5,
-                      template-haskell < 2.17,
+                      template-haskell < 2.18,
                       -- https://github.com/mboes/th-lift/issues/14
                       th-lift >= 0.7.1,
                       th-reify-many >= 0.1 && < 0.2,


### PR DESCRIPTION
The new version of `template-haskell` added a `Code` newtype (https://gitlab.haskell.org/ghc/ghc/-/merge_requests/3358).  I'm able to build under GHC 9.0.1-alpha1 with this change.