### PR TITLE
Add Quote instances for transformers data types

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.10
+# version: 0.10.3
 #
 version: ~> 1.0
 language: c
@@ -33,11 +33,11 @@ before_cache:
   - rm -rfv $CABALHOME/packages/head.hackage
 jobs:
   include:
-    - compiler: ghc-8.10.1
-      addons: {"apt":{"sources":[{"sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu xenial main","key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286"}],"packages":["ghc-8.10.1","cabal-install-3.2"]}}
+    - compiler: ghc-8.10.2
+      addons: {"apt":{"sources":[{"sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu xenial main","key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286"}],"packages":["ghc-8.10.2","cabal-install-3.2"]}}
       os: linux
-    - compiler: ghc-8.8.3
-      addons: {"apt":{"sources":[{"sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu xenial main","key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286"}],"packages":["ghc-8.8.3","cabal-install-3.2"]}}
+    - compiler: ghc-8.8.4
+      addons: {"apt":{"sources":[{"sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu xenial main","key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286"}],"packages":["ghc-8.8.4","cabal-install-3.2"]}}
       os: linux
     - compiler: ghc-8.6.5
       addons: {"apt":{"sources":[{"sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu xenial main","key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286"}],"packages":["ghc-8.6.5","cabal-install-3.2"]}}
@@ -159,5 +159,5 @@ script:
   # haddock...
   - ${CABAL} v2-haddock $WITHCOMPILER --with-haddock $HADDOCK ${TEST} ${BENCH} all
 
-# REGENDATA ("0.10",["--output=.travis.yml","--config=cabal.haskell-ci","cabal.project"])
+# REGENDATA ("0.10.3",["--output=.travis.yml","--config=cabal.haskell-ci","cabal.project"])
 # EOF

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 ### next [????.??.??]
+* Allow building with `template-haskell-2.17.0.0` (GHC 9.0).
+* Define `Quote` instances for `ReaderT`, `StateT`, `WriterT`, and `RWST`. In
+  order to define these instances on as many versions of `template-haskell` as
+  possible, this library now depends on the `th-compat` library, which
+  backports the `Quote` class to older versions of `template-haskell`.
 * Backport the `Semigroup`, `Monoid`, and `MonadFix` instances for `Q` that
   were introduced in `template-haskell-2.17.0.0`.
 

--- a/th-orphans.cabal
+++ b/th-orphans.cabal
@@ -20,8 +20,8 @@ tested-with:        GHC == 7.0.4
                   , GHC == 8.2.2
                   , GHC == 8.4.4
                   , GHC == 8.6.5
-                  , GHC == 8.8.3
-                  , GHC == 8.10.1
+                  , GHC == 8.8.4
+                  , GHC == 8.10.2
 synopsis:           Orphan instances for TH datatypes
 description:        Orphan instances for TH datatypes.  In particular, instances
                     for Ord and Lift, as well as a few missing Show / Eq.  These
@@ -31,7 +31,8 @@ extra-source-files: CHANGELOG.md, README.md
 
 library
   build-depends:      base >= 4.3 && < 5,
-                      template-haskell < 2.17,
+                      template-haskell < 2.18,
+                      th-compat >= 0.1 && < 0.2,
                       -- https://github.com/mboes/th-lift/issues/14
                       th-lift >= 0.7.1,
                       th-reify-many >= 0.1 && < 0.2,
@@ -52,6 +53,8 @@ library
 
   hs-source-dirs:     src
   ghc-options:        -Wall
+  if impl(ghc >= 8.6)
+    ghc-options:      -Wno-star-is-type
   exposed-modules:    Language.Haskell.TH.Instances
   other-modules:      Language.Haskell.TH.Instances.Internal
   default-language:   Haskell2010


### PR DESCRIPTION
Just like `th-orphans` currently defines `Quasi` instances for data types in `transformers`, it is also useful to define instances of the `Quote` class. This class was first introduced in `template-haskell-2.17.0.0`, but the `th-compat` library backports the definition of `Quote` back to earlier versions of `template-haskell`. Both are useful, so I decided to incur the extremely lightweight dependency on `th-compat` so that I could define these `Quasi` instances on as many versions of `template-haskell` as possible.

(NB: There has been some discussion about upstreaming these instances to `transformers` in https://gitlab.haskell.org/ghc/ghc/-/issues/18322, but this appears unlikely to happen in time for GHC 9.0.)

While I was in town, I had to make one small change to the `liftTyped` implementation for `Bytes` in order to make it compile with GHC 9.0. Luckily, `th-compat` also offers an `unsafeSpliceCoerce` function which takes care of the heavy lifting for us.