### PR TITLE
Implement `qGetPackageRoot` in `Quasi` instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### next [????.??.??]
+* Implement `qGetPackageRoot` (introduced in `template-haskell-2.19.0.0`)
+  for the `Quasi` instances defined in `th-orphans`.
+
 ### 0.13.12 [2021.08.30]
 * Implement `qGetDoc` and `qPutDoc` (introduced in `template-haskell-2.18.0.0`)
   for the `Quasi` instances defined in `th-orphans`.

--- a/src/Language/Haskell/TH/Instances/Internal.hs
+++ b/src/Language/Haskell/TH/Instances/Internal.hs
@@ -91,6 +91,9 @@ deriveQuasiTrans qInstHead qRecoverExpr = do
             , ('qGetDoc,             [| MTL.lift . qGetDoc |])
             , ('qPutDoc,             [| \a b -> MTL.lift $ qPutDoc a b |])
 #endif
+#if MIN_VERSION_template_haskell(2,19,0)
+            , ('qGetPackageRoot,     [| MTL.lift qGetPackageRoot |])
+#endif
             ]
 
           mkDec :: Name -> Q Exp -> Q Dec

--- a/th-orphans.cabal
+++ b/th-orphans.cabal
@@ -33,7 +33,7 @@ extra-source-files: CHANGELOG.md, README.md
 
 library
   build-depends:      base >= 4.3 && < 5,
-                      template-haskell < 2.19,
+                      template-haskell < 2.20,
                       th-compat >= 0.1 && < 0.2,
                       -- https://github.com/mboes/th-lift/issues/14
                       th-lift >= 0.7.1,


### PR DESCRIPTION
`qGetPackageRoot` was added to `Quasi` in `template-haskell-2.19.0.0`, which is bundled with GHC 9.4.