### PR TITLE
Only need th-lift-instances for GHC 7.8 and below

### DIFF
--- a/src/Language/Haskell/TH/Instances.hs
+++ b/src/Language/Haskell/TH/Instances.hs
@@ -69,7 +69,9 @@ import Control.Monad.RWS (RWST(RWST), runRWST)
 import Control.Monad.State (StateT(StateT), runStateT)
 import qualified Control.Monad.Trans as Trans (MonadTrans(lift))
 import Control.Monad.Writer (WriterT(WriterT), runWriterT)
+#if !MIN_VERSION_base(4,8,0)
 import Instances.TH.Lift ()
+#endif
 
 #if !(MIN_VERSION_template_haskell(2,8,0))
 import Unsafe.Coerce (unsafeCoerce)

--- a/th-orphans.cabal
+++ b/th-orphans.cabal
@@ -38,7 +38,6 @@ library
                       -- https://github.com/mboes/th-lift/issues/14
                       th-lift >= 0.7.1,
                       th-reify-many >= 0.1.9 && < 0.2,
-                      th-lift-instances,
                       mtl >= 2
 
   if !impl(ghc >= 8.0)
@@ -48,6 +47,7 @@ library
   -- Use TH to derive Generics instances instead of DeriveGeneric, for < 7.10
   if impl(ghc < 7.10)
     build-depends:    generic-deriving >= 1.9
+                    , th-lift-instances
 
   -- Prior to GHC 7.6, GHC generics lived in ghc-prim
   if impl(ghc >= 7.2) && impl(ghc < 7.6)


### PR DESCRIPTION
I think this is only needed on GHC 7.8 and below.

See phadej/file-embed-lzma#11.
